### PR TITLE
AngularJS provokes a NullPointerException in HTMLEditor when invoking CA...

### DIFF
--- a/org.eclipse.angularjs.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.angularjs.ui/META-INF/MANIFEST.MF
@@ -23,7 +23,8 @@ Require-Bundle: org.eclipse.ui,
  tern.core;bundle-version="1.0.0",
  tern.eclipse;bundle-version="1.0.0",
  org.eclipse.ui.ide,
- tern.eclipse.ide.ui;bundle-version="1.0.0"
+ tern.eclipse.ide.ui;bundle-version="1.0.0",
+ org.eclipse.wst.jsdt.web.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Import-Package: org.json.simple

--- a/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/editor/adapter/AdapterFactoryProviderForAngular.java
+++ b/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/editor/adapter/AdapterFactoryProviderForAngular.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 IBM Corporation and others.
+ * Copyright (c) 2009, 2014 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package org.eclipse.angularjs.internal.ui.editor.adapter;
 
 import org.eclipse.angularjs.internal.core.documentModel.handler.AngularModelHandler;
 import org.eclipse.wst.html.ui.internal.contentoutline.JFaceNodeAdapterFactoryForHTML;
+import org.eclipse.wst.jsdt.web.core.javascript.JsTranslationAdapterFactory;
 import org.eclipse.wst.sse.core.internal.PropagatingAdapter;
 import org.eclipse.wst.sse.core.internal.ltk.modelhandler.IDocumentTypeHandler;
 import org.eclipse.wst.sse.core.internal.model.FactoryRegistry;
@@ -48,6 +49,8 @@ public class AdapterFactoryProviderForAngular implements AdapterFactoryProvider 
 					IJFaceNodeAdapter.class, true);
 			factoryRegistry.addFactory(factory);
 		}
+		
+		JsTranslationAdapterFactory.setupAdapterFactory(structuredModel);
 	}
 
 	protected void addPropagatingAdapters(IStructuredModel structuredModel) {


### PR DESCRIPTION
... in JavaScript inside 'script' tag

Since the AngularJS-eclipse's has its own AdapterFactoryProviderForAngular, org.eclipse.wst.jsdt.web.core.javascript.JsTranslationAdapterFactory is not initialized for an HTML document. This makes the default (JSDT) Content Assistant fail to operate on HTML files. Actually the standard JSDT Content Assist is removed (since it's not initialized) from the editor, when AngularJS-eclipse is installed. 

(See the related issue in Webtools.sourceediting: https://bugs.eclipse.org/bugs/show_bug.cgi?id=429517 - NullPointerException in JSDTContentAssistant.computeCompletionProposals())

I'm not sure that the removal of JSDT CA from the websource editing was the goal of AngularJS-eclipse, so, I'd propose to apply this fix in order to restore JSDT CA's functionality on AngularJS-enabled HTML documents.
