### PR TITLE
[question] Can AngularJS HTML Editor ...

### DIFF
--- a/org.eclipse.angularjs.core/plugin.xml
+++ b/org.eclipse.angularjs.core/plugin.xml
@@ -100,6 +100,7 @@
                <fileext caseSensitive="false" ext="htm"/>
                <fileext caseSensitive="false" ext="htpl"/>
                <fileext caseSensitive="false" ext="wml"/>
+               <fileext caseSensitive="false" ext="ejs"/>
             </rules>
          </include>
          <group id="org.eclipse.wst.sse.core.structuredModelGroup"/>


### PR DESCRIPTION
Can AngularJS HTML Editor digest more files, e.g. .ejs, [tymeleaf](http://www.thymeleaf.org/) and many more template engines with warying extention, and sometime not strict HTML grammar.

WTP HTML Editor default behavior is to give up, saying that "Content type is not supported"
