### PR TITLE
Make AngularJS-eclipse 'convert project ...' action bevare of that Tern....

### DIFF
--- a/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/handlers/ConvertProjectToAngularCommandHandler.java
+++ b/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/handlers/ConvertProjectToAngularCommandHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.handlers.HandlerUtil;
 
+import tern.eclipse.ide.core.IDETernProject;
 import tern.eclipse.ide.core.TernNature;
 
 /**
@@ -52,6 +53,8 @@ public class ConvertProjectToAngularCommandHandler extends AbstractHandler {
 			public IStatus runInWorkspace(IProgressMonitor monitor)
 					throws CoreException {
 
+				boolean adoptedToTern = IDETernProject.hasTernNature(project);
+				
 				IProjectDescription projectDescription = project
 						.getDescription();
 
@@ -81,8 +84,9 @@ public class ConvertProjectToAngularCommandHandler extends AbstractHandler {
 						newNatures.add(natures[c]);
 					}
 				}
+				if (!adoptedToTern) // Add Tern Nature only if the project is not adopted
+					newNatures.add(TernNature.ID);
 				newNatures.add(AngularNature.ID);
-				newNatures.add(TernNature.ID);
 
 				projectDescription.setNatureIds((String[]) newNatures
 						.toArray(new String[newNatures.size()]));


### PR DESCRIPTION
...java

is able to treat a custom project nature as Tern nature.

If some project has a nature that is configured to be treated as Tern nature, then
that nature is used as a Tern nature when converting to AngularJS project instead of adding Tern nature.

depends on: https://github.com/angelozerr/tern.java/pull/38

Signed-off-by: vrubezhny vrubezhny@exadel.com
