### PR TITLE
Angular Nature adds the same Libs into .tern-project multiple times when...

### DIFF
--- a/org.eclipse.angularjs.core/src/org/eclipse/angularjs/core/AngularNature.java
+++ b/org.eclipse.angularjs.core/src/org/eclipse/angularjs/core/AngularNature.java
@@ -18,8 +18,13 @@ import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.CoreException;
 
 import tern.TernProject;
+import tern.server.ITernPlugin;
 import tern.server.TernDef;
 import tern.server.TernPlugin;
+
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
 
 /**
  * AngularJS Nature.
@@ -33,20 +38,51 @@ public class AngularNature implements IProjectNature {
 	private IProject project;
 
 	public void configure() throws CoreException {
+		boolean saveRequired = false;
+		
 		// Add "angular" plugin
 		TernProject ternProject = AngularProject.getTernProject(project);
-		ternProject.addPlugin(TernPlugin.angular);
+		if (!containsPlugin(ternProject, TernPlugin.angular)) {
+			saveRequired = true;
+			ternProject.addPlugin(TernPlugin.angular);
+		}
+		
 		// Add "browser" + "ecma5" JSON Type Def
-		ternProject.addLib(TernDef.browser.name());
-		ternProject.addLib(TernDef.ecma5.name());
-		try {
-			ternProject.save();
-		} catch (IOException e) {
-			Trace.trace(Trace.SEVERE,
-					"Error while configuring angular nature.", e);
+		if (!containsLib(ternProject, TernDef.browser.name())) {
+			saveRequired = true;
+			ternProject.addLib(TernDef.browser.name());
+		}
+		if (!containsLib(ternProject, TernDef.ecma5.name())) {
+			saveRequired = true;
+			ternProject.addLib(TernDef.ecma5.name());
+		}
+		
+		if (saveRequired) {
+			try {
+				ternProject.save();
+			} catch (IOException e) {
+				Trace.trace(Trace.SEVERE,
+						"Error while configuring angular nature.", e);
+			}
 		}
 	}
 
+	public boolean containsPlugin(TernProject ternProject, ITernPlugin plugin) {
+		JsonObject plugins = ternProject.getPlugins(); // No null can be returned here
+		return (plugins.get(plugin.getName()) != null);
+	}
+	
+	public boolean containsLib(TernProject ternProject, String libName) {
+		JsonArray libs = ternProject.getLibs();
+		if (libs != null) {
+			for (JsonValue lib : libs) {
+				if (lib.isString() && lib.asString().equals(libName))
+					return true;
+			}
+		}
+		return false;
+	}
+	
 	public void deconfigure() throws CoreException {
 		// Remove the nature-specific information here.
 	}


### PR DESCRIPTION
... configured

At the moment the case can be only when manually removing the Angular Nature from .project file and then using "Convert to AngularJS Project". There is no check on that library is to be added already exists on Tern Project. As such, when converting a project into AngularJS Project, if .tern-project is already exist on that project, the "ecma5" and "browser" libraries are duplicated in .tern-project file and in memory (TernProject's JSONObject).

Also, I need the changes made in this fix in order to properly configure the .tern-project file in case of AngularJS-eclipse is adopted to a nature other than Angular Nature. (See: https://github.com/angelozerr/angularjs-eclipse/pull/55)

Signed-off-by: vrubezhny vrubezhny@exadel.com
