### PR TITLE
link to http://angularjs.org/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AngularJS Eclipse Plugin
 
 AngularJS Eclipse Plugin extends Eclipse WTP to :
 
- * provides an HTML editor which supports AngularJS expression and directive. See [HTML features](https://github.com/angelozerr/angularjs-eclipse/wiki/HTML-Features) for more informations.
+ * provides an HTML editor which supports [AngularJS](http://angularjs.org/) expression and directive. See [HTML features](https://github.com/angelozerr/angularjs-eclipse/wiki/HTML-Features) for more informations.
  * provides an [Angular Explorer](https://github.com/angelozerr/angularjs-eclipse/wiki/Angular-Explorer-View) view which displays modules, controllers of your project in a tree.
  * provides a Javascript editor which supports AngularJS features (modules, etc). See [Javascript features](https://github.com/angelozerr/angularjs-eclipse/wiki/Javascript-Features) for more informations.
 


### PR DESCRIPTION
I wonder why there were no direct links
