### PR TITLE
Check for null displayText

### DIFF
--- a/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/taginfo/HTMLAngularTagInfoHoverProcessor.java
+++ b/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/taginfo/HTMLAngularTagInfoHoverProcessor.java
@@ -80,6 +80,11 @@ public class HTMLAngularTagInfoHoverProcessor extends HTMLTagInfoHoverProcessor
 
 		int documentOffset = hoverRegion.getOffset();
 		String displayText = computeHoverHelp(viewer, documentOffset);
+
+		if(displayText == null) {
+		    return null;
+		}
+
 		return new TernBrowserInformationControlInput(null, displayText, 200);
 	}
 


### PR DESCRIPTION
In my dev environment with the latest tern.java and angularjs plugins I have seen this NPE several times:

```
org.eclipse.core.runtime.AssertionFailedException: null argument:
    at org.eclipse.core.runtime.Assert.isNotNull(Assert.java:85)
    at org.eclipse.core.runtime.Assert.isNotNull(Assert.java:73)
    at tern.eclipse.jface.text.TernBrowserInformationControlInput.<init>(TernBrowserInformationControlInput.java:43)
    at org.eclipse.angularjs.internal.ui.taginfo.HTMLAngularTagInfoHoverProcessor.getHoverInfo2(HTMLAngularTagInfoHoverProcessor.java:88)
    at org.eclipse.wst.sse.ui.internal.taginfo.BestMatchHover.getHoverInfo2(BestMatchHover.java:139)
    at org.eclipse.jface.text.TextViewerHoverManager$4.run(TextViewerHoverManager.java:166)

```

This commit adds a simple null check
