### PR TITLE
AngularJS Plug-in is not installed by default for AngularJS Project

### DIFF
--- a/org.eclipse.angularjs.core/src/org/eclipse/angularjs/core/AngularProject.java
+++ b/org.eclipse.angularjs.core/src/org/eclipse/angularjs/core/AngularProject.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.angularjs.core;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,8 +39,10 @@ import tern.eclipse.ide.core.ITernProjectLifecycleListener;
 import tern.eclipse.ide.core.TernCorePlugin;
 import tern.scriptpath.ITernScriptPath;
 import tern.server.ITernServer;
+import tern.server.TernDef;
 import tern.server.TernPlugin;
 import tern.server.TernServerAdapter;
+import tern.utils.TernModuleHelper;
 
 /**
  * Angular project.
@@ -155,6 +158,22 @@ public class AngularProject implements IDirectiveSyntax,
 				List<String> angularNatureAdapters = getAngularNatureAdapters();
 				for (String adaptToNature : angularNatureAdapters) {
 					if (project.hasNature(adaptToNature)) {
+						if (!TernCorePlugin.getTernProject(project).hasPlugin(TernPlugin.angular)) {
+							IIDETernProject ternProject = TernCorePlugin.getTernProject(project,
+									false);
+
+							// add default JSON type definitions and plugins
+							TernModuleHelper.update(TernPlugin.angular, ternProject);
+							TernModuleHelper.update(TernDef.browser, ternProject);
+							TernModuleHelper.update(TernDef.ecma5, ternProject);
+							// save tern project if needed
+							try {
+								ternProject.save();
+							} catch (IOException e) {
+								Trace.trace(Trace.SEVERE,
+										"Error while configuring angular nature.", e);
+							}
+						}
 						return true;
 					}
 				}


### PR DESCRIPTION
Previously, with having Tern/AngularJS Natures, the Tern Project was setup accordingly (required definitions and plugins were set up on the project). Now, for the adopted projects there is no such a 'convertation', so, as the result, for an angular project we have no angular plug-in set up in .tern-project file.

Signed-off-by: vrubezhny vrubezhny@exadel.com
