### PR TITLE
Add the Linux 32-bit NodeJS Embed fragement to the p2 repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
 						<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
+							<arch>x86</arch>
+						</environment>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
 						<environment>


### PR DESCRIPTION
The p2 repository misses the NodeJS Embed fragment for Linux 32-bit. This is because the parent pom.xml was not configured to build for this platform type.