### PR TITLE
Fix: quid:S2583 Conditions should not unconditionally evaluate to "Tr…

### DIFF
--- a/org.eclipse.angularjs.core/src/org/eclipse/angularjs/core/utils/DOMUtils.java
+++ b/org.eclipse.angularjs.core/src/org/eclipse/angularjs/core/utils/DOMUtils.java
@@ -97,13 +97,11 @@ public class DOMUtils {
 				return (IDOMNode) node;
 			}
 
-			if (model != null) {
-				int lastOffset = offset;
-				node = model.getIndexedRegion(offset);
-				while (node == null && lastOffset >= 0) {
-					lastOffset--;
-					node = model.getIndexedRegion(lastOffset);
-				}
+			int lastOffset = offset;
+			node = model.getIndexedRegion(offset);
+			while (node == null && lastOffset >= 0) {
+				lastOffset--;
+				node = model.getIndexedRegion(lastOffset);
 			}
 		}
 		return (IDOMNode) node;
@@ -549,8 +547,7 @@ public class DOMUtils {
 		if (model == null)
 			return null;
 		if (!(model instanceof IDOMModel)) {
-			if (model != null)
-				model.releaseFromRead();
+			model.releaseFromRead();
 			return null;
 		}
 		return (IDOMModel) model;

--- a/org.eclipse.angularjs.jsp.ui/src/org/eclipse/angularjs/jsp/internal/ui/org/eclipse/jst/jsp/ui/internal/validation/JSPContentSourceValidator.java
+++ b/org.eclipse.angularjs.jsp.ui/src/org/eclipse/angularjs/jsp/internal/ui/org/eclipse/jst/jsp/ui/internal/validation/JSPContentSourceValidator.java
@@ -182,8 +182,7 @@ public class JSPContentSourceValidator extends JSPContentValidator implements IS
 			}
 		}
 		finally {
-			if (model != null)
-				model.releaseFromRead();
+			model.releaseFromRead();
 		}
 	}
 

--- a/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/views/AngularExplorerViewOLD.java
+++ b/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/views/AngularExplorerViewOLD.java
@@ -263,7 +263,7 @@ public class AngularExplorerViewOLD extends ViewPart implements
 			return;
 		//this.terminateAction.setEnabled(false);
 		currentEditor = part;
-		if (part != null && part instanceof IEditorPart) {
+		if (part instanceof IEditorPart) {
 			currentResource = null;
 			Object sel = ((IEditorPart) part).getEditorInput();
 			if (sel instanceof IAdaptable) {

--- a/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/views/actions/UnLinkToControllerAction.java
+++ b/org.eclipse.angularjs.ui/src/org/eclipse/angularjs/internal/ui/views/actions/UnLinkToControllerAction.java
@@ -49,8 +49,7 @@ public class UnLinkToControllerAction extends Action {
 				IModule module = element.getModule();
 				if (module != null) {
 					try {
-						AngularLinkHelper.removeController(resource, null, module.getName(),
-								element != null ? element.getName() : null, null);
+						AngularLinkHelper.removeController(resource, null, module.getName(), element.getName(), null);
 						page.updateEnabledLinkActions(true);
 						// explorer.refreshTree(true);
 					} catch (Exception e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2583 - “ Conditions should not unconditionally evaluate to ""TRUE"" or to ""FALSE"" ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2583
 Please let me know if you have any questions.
Ayman Elkfrawy